### PR TITLE
docs(README): add “By Certificates” shields badge linking to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ URL: https://georgemaia.github.io/certificados
     <img src="https://img.shields.io/badge/-LinkedIn-blue?style=flat-square&logo=Linkedin&logoColor=white&link=https://www.linkedin.com/in/georgemaia/">
 </a>
 
+<a href="https://github.com/georgemaia/certificados">
+    <img src="https://img.shields.io/badge/By-Certificates-critical?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAQCAMAAAAs2N9uAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAYlQTFRFDkaRC0OQADeIAB57AB16ADyKDEORBjyJC0aSADSHKVqc9/b56e305+vz////CT6OADeIBzyKAD2NAANp0dno5enxAAdtADiIDEWQ+fj4oKKlra6xoqOn7u7tACJ5CEKQ/v79zMzN1dTVzc3O9vb3AB94B0GP/v7+6Ojp7Ozt6Ojq+/v7AB549vX1hIaIlJaYgYCF/vHO/b47+8SC+fn6pqaqtLS3tLS4oaOl//np/acA/K4A+YQA+atBDEWS/v7/0tLU2trc0NDT/uWq/awA/LYU+ZQU+pUJACB5Aj6NqbfV//78xsjJzs/QztDQxMTH/vvz/rkA/sMP/p8I/rZVx8/jACl+BkKPABJzfJnC/6No+oMD3DcAdJbJABNzBTuKC0WRATyLCkCNZYO2YIC0X3+zS4/KrDhl9AAX2wAAX53UADWJBD6NCD2LACx+ACF3Aj+OADOGADGGADmb5hcl9Bge7Q4JADWIAEOVCUOQCD+NAAAA9xsk6xoiyhAWW8fyW8fy5Cs3wh8qFypTlwAAAIN0Uk5Tv7+/v7+/v+3///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////83MyEhIQa3//8lHCEyAJP//wECNUeuPNI/AAAA1klEQVR4nGNgYGRiZkEAVjZ2Bg5OLm4eXhjg4xcQZBASFuFDAqJi4gwSfHySUtJQICPLxyfHIM/Hp6CoBAXKKnx8qgxqfHzqGppQoKXNx6cDEkIFYCFdPX19fQM+PkMjY5iQiamZmbkFn6WVtY0tSMiOj8/ewdHR0YnP2cXVzZ2Pz4PB04vP28fX18+fLyAwKDiELzSMITwiEmZwVHQMX2xcPENCYlJySioIpKVnZGZl5+Qy5OUXFBaBQXFJaVl5RWUVQzUC1NTWgSiG6voGmFBjdROIAgBJkTv/kHbjnAAAAABJRU5ErkJggg==">
+</a>
+
 ## USAGE
 
 In the settings page of the repository, turn on Github Pages. After, change the SERVER constant in the config.js with your full address of the certificates files.


### PR DESCRIPTION
Adds a Shields badge “By Certificates” to README.md, pointing to the repository and using an embedded base64 logo.


What’s changed
Inserted a badge below the social links:
Label: “By Certificates”
Color: critical
Link: https://github.com/georgemaia/certificados
Logo: inlined via base64 (per issue #15 request)

